### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,10 @@ Currently will not consider adding OAuth endpoints. (those required "authorized 
 
 
 ## Install
-Example composer.json
+Installation is easy with composer just run.
 
-```json
-{
-    "name": "MyCoolProject",
-    "require": {
-        "madcoda/php-youtube-api" : "dev-master"
-    }
-}
-```
-
-Run the Install
-
-```bash
-$ composer install
-
-# Run "composer update" instead if you already has a composer.json before
-$ composer update
+```sh
+composer require madcoda/php-youtube-api
 ```
 
 ## Usage (Plain PHP project)


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
