### PR TITLE
Add getVideosInfo method

### DIFF
--- a/lib/Madcoda/Youtube.php
+++ b/lib/Madcoda/Youtube.php
@@ -65,6 +65,24 @@ class Youtube
     }
 
     /**
+     * @param $vIds
+     * @return \StdClass
+     * @throws \Exception
+     */
+    public function getVideosInfo($vIds)
+    {
+        $ids = is_array($vIds) ? implode(',', $vIds) : $vIds;
+        $API_URL = $this->getApi('videos.list');
+        $params = array(
+            'id' => $ids,
+            'part' => 'id, snippet, contentDetails, player, statistics, status'
+        );
+
+        $apiData = $this->api_get($API_URL, $params);
+        return $this->decodeList($apiData);
+    }
+
+    /**
      * Simple search interface, this search all stuffs
      * and order by relevance
      *

--- a/test/Madcoda/Tests/YoutubeTest.php
+++ b/test/Madcoda/Tests/YoutubeTest.php
@@ -82,6 +82,24 @@ class YoutubeTest extends \PHPUnit_Framework_TestCase
         $this->assertObjectHasAttribute('contentDetails', $response);
     }
 
+    public function testGetVideosInfo()
+    {
+        $vID = array('rie-hPVJ7Sw', 'lRRk97FYLJM');
+        $response = $this->youtube->getVideosInfo($vID);
+        $this->assertInternalType('array', $response);
+        
+        foreach ($response as $value) {
+            $this->assertContains($value->id, $vID);
+            $this->assertEquals('youtube#video', $value->kind);
+            //add all these assertions here in case the api is changed,
+            //we can detect it instantly
+            $this->assertObjectHasAttribute('statistics', $value);
+            $this->assertObjectHasAttribute('status', $value);
+            $this->assertObjectHasAttribute('snippet', $value);
+            $this->assertObjectHasAttribute('contentDetails', $value);
+        }
+    }
+
     public function testSearch()
     {
         $limit = rand(3, 10);


### PR DESCRIPTION
Hello. There is a feature in youtube api that can get information about several videos in one request using comma separated string of videos' id. I think it will be usefull to have method that can use this feature.