### PR TITLE
Add option to set referer

### DIFF
--- a/lib/Madcoda/Youtube.php
+++ b/lib/Madcoda/Youtube.php
@@ -14,6 +14,11 @@ class Youtube
     protected $youtube_key; //pass in by constructor
 
     /**
+     * @var string
+     */
+    protected $referer;
+
+    /**
      * @var array
      */
     var $APIs = array(
@@ -28,7 +33,7 @@ class Youtube
     /**
      * @var array
      */
-    var $page_info = array();
+    public $page_info = array();
 
     /**
      * Constructor
@@ -37,12 +42,19 @@ class Youtube
      * @param array $params
      * @throws \Exception
      */
-    public function __construct($params)
+    public function __construct($params = array())
     {
-        if (is_array($params) && array_key_exists('key', $params)) {
-            $this->youtube_key = $params['key'];
-        } else {
-            throw new \Exception('Google API key is Required, please visit http://code.google.com/apis/console');
+        if (!is_array($params)) {
+            throw new \InvalidArgumentException('The configuration options must be an array.');
+        }
+
+        if (!array_key_exists('key', $params)) {
+            throw new \InvalidArgumentException('Google API key is required, please visit http://code.google.com/apis/console');
+        }
+        $this->youtube_key = $params['key'];
+
+        if (array_key_exists('referer', $params)) {
+            $this->referer = $params['referer'];
         }
     }
 
@@ -453,6 +465,9 @@ class Youtube
             curl_setopt($tuCurl, CURLOPT_PORT, 80);
         } else {
             curl_setopt($tuCurl, CURLOPT_PORT, 443);
+        }
+        if ($this->referer !== null) {
+            curl_setopt($tuCurl, CURLOPT_REFERER, $this->referer);
         }
         curl_setopt($tuCurl, CURLOPT_RETURNTRANSFER, 1);
         $tuData = curl_exec($tuCurl);

--- a/test/Madcoda/Tests/YoutubeTest.php
+++ b/test/Madcoda/Tests/YoutubeTest.php
@@ -18,7 +18,7 @@ class YoutubeTest extends \PHPUnit_Framework_TestCase
     /**
      * @var Youtube
      */
-    var $youtube;
+    protected $youtube;
 
     public function setUp()
     {
@@ -40,7 +40,7 @@ class YoutubeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \InvalidArgumentException
      */
     public function testConstructorFail()
     {
@@ -48,7 +48,7 @@ class YoutubeTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Exception
+     * @expectedException \InvalidArgumentException
      */
     public function testConstructorFail2()
     {


### PR DESCRIPTION
In some cases, the YouTube API key has restrictions for the allowed 'Referer' HTTP header. In my case, whenever I develop on my local machine, I have to set the referer to my production instance (e.g. `www.prod-ytapp.com`).

This patch allows to pass `'referer'` as configuration option to the constructor. It does not break BC.