### PR TITLE
Add curl_errno() to one exception

### DIFF
--- a/lib/Madcoda/Youtube.php
+++ b/lib/Madcoda/Youtube.php
@@ -472,7 +472,7 @@ class Youtube
         curl_setopt($tuCurl, CURLOPT_RETURNTRANSFER, 1);
         $tuData = curl_exec($tuCurl);
         if (curl_errno($tuCurl)) {
-            throw new \Exception('Curl Error : ' . curl_error($tuCurl));
+            throw new \Exception('Curl Error : ' . curl_error($tuCurl), curl_errno($tuCurl));
         }
         return $tuData;
     }


### PR DESCRIPTION
Add curl_errno() to Exception (fixes bug I introduced earlier this year when I accidentally added curl_error() as the second parameter of the Exception - sorry about that!)