### PR TITLE
Allow optional parameters for activities call

### DIFF
--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -442,7 +442,7 @@ class Youtube
      * @return array
      * @throws \Exception
      */
-    public function getActivitiesByChannelId($channelId)
+    public function getActivitiesByChannelId($channelId, $optionalParams = false)
     {
         if (empty($channelId)) {
             throw new \InvalidArgumentException('ChannelId must be supplied');
@@ -452,6 +452,9 @@ class Youtube
             'channelId' => $channelId,
             'part' => 'id, snippet, contentDetails'
         );
+        if ($optionalParams) {
+            $params = array_merge($params, $optionalParams);
+        }
         $apiData = $this->api_get($API_URL, $params);
         return $this->decodeList($apiData);
     }


### PR DESCRIPTION
I ran into an issue that getActivitiesByChannelId only returns 5 entries and nothing more. With this change, you can hand over the maxResults parameter to get more or less results.