### PR TITLE
"YouTube" is not a namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For the functions implemented in this library, please visit [API Reference](http
 ### Example usage with pure PHP (with composer)
 ```php
 require 'vendor/autoload.php';
-$youtube = new Madcoda\Youtube\Youtube(array('key' => '* Your API key here *'));
+$youtube = new Madcoda\Youtube(array('key' => '* Your API key here *'));
 $video = $youtube->getVideoInfo('rie-hPVJ7Sw');
 ```
 


### PR DESCRIPTION
While it is a namespace and should be `new \Madcoda\YouTube\YouTube()` as per PSR-4, it is in fact just `new \Madcoda\YouTube()`