### PR TITLE
Fix UnexpectedPart "invideoPromotion" error

### DIFF
--- a/src/Youtube.php
+++ b/src/Youtube.php
@@ -309,7 +309,7 @@ class Youtube
         $API_URL = $this->getApi('channels.list');
         $params = array(
             'forUsername' => $username,
-            'part' => 'id,snippet,contentDetails,statistics,invideoPromotion'
+            'part' => 'id,snippet,contentDetails,statistics'
         );
         if ($optionalParams) {
             $params = array_merge($params, $optionalParams);
@@ -329,7 +329,7 @@ class Youtube
         $API_URL = $this->getApi('channels.list');
         $params = array(
             'id' => $id,
-            'part' => 'id,snippet,contentDetails,statistics,invideoPromotion'
+            'part' => 'id,snippet,contentDetails,statistics'
         );
         if ($optionalParams) {
             $params = array_merge($params, $optionalParams);
@@ -348,7 +348,7 @@ class Youtube
         $API_URL = $this->getApi('channels.list');
         $params = array(
             'id' => implode(',', $ids),
-            'part' => 'id,snippet,contentDetails,statistics,invideoPromotion'
+            'part' => 'id,snippet,contentDetails,statistics'
         );
         if($optionalParams){
             $params = array_merge($params, $optionalParams);
@@ -583,7 +583,7 @@ class Youtube
         } else {
             $this->page_info = array(
                 'resultsPerPage' => $resObj->pageInfo->resultsPerPage,
-                'totalResults'   => $resObj->pageInfo->totalResults,
+                'totalResults'   => isset($resObj->pageInfo->totalResults) ? $resObj->pageInfo->totalResults : null,
                 'kind'           => $resObj->kind,
                 'etag'           => $resObj->etag,
                 'prevPageToken'     => null,


### PR DESCRIPTION
Channels "invideoPromotion" part is deprecated and causes API error

`{ "error": { "code": 400, "message": "'invideo_promotion'", "errors": [ { "message": "'invideo_promotion'", "domain": "youtube.part", "reason": "unexpectedPart", "location": "part", "locationType": "parameter" } ] } }`

Also, using getChannelsById method produces `Notice: Undefined property: stdClass::$totalResults since the property is missing` so I've also modified line 586 (not sure if it's deprecated or for some other reasons)